### PR TITLE
Update to 42.0

### DIFF
--- a/org.gnome.Connections.json
+++ b/org.gnome.Connections.json
@@ -1,13 +1,14 @@
 {
     "app-id": "org.gnome.Connections",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "41",
+    "runtime-version": "42",
     "sdk": "org.gnome.Sdk",
     "command": "gnome-connections",
     "finish-args": [
         "--share=network",
         "--share=ipc",
         "--socket=fallback-x11",
+        "--socket=pulseaudio",
         "--socket=wayland"
     ],
     "cleanup": [
@@ -26,6 +27,9 @@
         {
             "name" : "gtk-vnc",
             "buildsystem" : "meson",
+            "config-opts" : [
+                "-Dpulseaudio=enabled"
+            ],
             "sources" : [
                 {
                     "type" : "archive",
@@ -80,7 +84,7 @@
                 {
                     "type" : "git",
                     "url" : "https://gitlab.gnome.org/gnome/gtk-frdp.git",
-                    "branch" : "gtk-frdp-0-1"
+                    "branch" : "a44d84ec687f41ad37e43697b28a018f65780780"
                 }
             ]
         },
@@ -92,7 +96,7 @@
                 {
                     "type": "git",
                     "url": "https://gitlab.gnome.org/gnome/connections.git",
-                    "branch": "gnome-41"
+                    "commit": "27541cbe59d836480b16ef37700be26fb2c1edad"
                 }
             ]
         }


### PR DESCRIPTION
The specified commit for gnome-connections 27541cb corresponds to the
42.0 release tarball.

The commit for gtk-frdp is the one used in the
manifest upstream.

pulseaudio changes mimic upstream.

The reason to use `27541cbe59d836480b16ef37700be26fb2c1edad` is that using `gnome-42` will use a commit which is not the same one used for the release tarball, and makes builds non-reproducible. Specifying both the commit and the branch also fails since "27541cbe59d836480b16ef37700be26fb2c1edad" is not the last commit of the branch. I would suggest using the sources at https://download.gnome.org/sources/gnome-connections/42/ for readability, but that's besides the point of the PR.