### PR TITLE
Use shared-modules/libusb

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "shared-modules"]
+	path = shared-modules
+	url = https://github.com/flathub/shared-modules

--- a/org.gnome.Connections.json
+++ b/org.gnome.Connections.json
@@ -38,19 +38,7 @@
                 }
             ]
         },
-        {
-            "name" : "libusb",
-            "config-opts" : [
-                "--disable-udev"
-            ],
-            "sources" : [
-                {
-                    "type" : "archive",
-                    "url" : "https://github.com/libusb/libusb/releases/download/v1.0.23/libusb-1.0.23.tar.bz2",
-                    "sha256" : "db11c06e958a82dac52cf3c65cb4dd2c3f339c8a988665110e0d24d19312ad8d"
-                }
-            ]
-        },
+        "shared-modules/libusb/libusb.json",
         {
             "name" : "freerdp",
             "buildsystem": "cmake-ninja",


### PR DESCRIPTION
Note that there is a difference in the config opts

The previous build used "--disable-udev", wheread shared modules uses "--disable-static", I am not sure whether this is relevant or not. It also bumps to 1.0.25.

- https://github.com/flathub/shared-modules/blob/master/libusb/libusb.json